### PR TITLE
call to list/list requires the param ids. Post data added to the list/li...

### DIFF
--- a/includes/List.class.php
+++ b/includes/List.class.php
@@ -58,9 +58,9 @@ class AC_List_ extends ActiveCampaign {
 		return $response;
 	}
 
-	function list_($params) {
+	function list_($params, $post_data) {
 		$request_url = "{$this->url}&api_action=list_list&api_output={$this->output}&{$params}";
-		$response = $this->curl($request_url);
+		$response = $this->curl($request_url, $post_data);
 		return $response;
 	}
 


### PR DESCRIPTION
According to http://www.activecampaign.com/api/example.php?call=list_list, the param 'ids' is required. 
This was not possible in the previous implementation.
