### PR TITLE
add if statement for class redeclaration

### DIFF
--- a/includes/Account.class.php
+++ b/includes/Account.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Account')) {
+
 class AC_Account extends ActiveCampaign {
 
 	public $version;
@@ -70,4 +72,5 @@ class AC_Account extends ActiveCampaign {
 
 }
 
+}
 ?>

--- a/includes/ActiveCampaign.class.php
+++ b/includes/ActiveCampaign.class.php
@@ -6,6 +6,8 @@ if ( !defined("ACTIVECAMPAIGN_URL") || (!defined("ACTIVECAMPAIGN_API_KEY") && !d
 
 require_once("Connector.class.php");
 
+if(!class_exists('ActiveCampaign')) {
+
 class ActiveCampaign extends AC_Connector {
 
 	public $url_base;
@@ -105,6 +107,8 @@ class ActiveCampaign extends AC_Connector {
 		$response = $class->$method($params, $post_data);
 		return $response;
 	}
+
+}
 
 }
 

--- a/includes/Auth.class.php
+++ b/includes/Auth.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Auth')) {
+    
 class AC_Auth extends ActiveCampaign {
 
 	public $version;
@@ -19,6 +21,8 @@ class AC_Auth extends ActiveCampaign {
 		$response = $this->curl($request_url);
 		return $response;
 	}
+
+}
 
 }
 

--- a/includes/Campaign.class.php
+++ b/includes/Campaign.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Campaign')) {
+    
 class AC_Campaign extends ActiveCampaign {
 
 	public $version;
@@ -130,4 +132,6 @@ class AC_Campaign extends ActiveCampaign {
 
 }
 
+
+                }
 ?>

--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Connector')) {
+    
 class AC_Connector {
 
 	public $url;
@@ -215,6 +217,8 @@ class AC_Connector {
 		}
 		return $object;
 	}
+
+}
 
 }
 

--- a/includes/Contact.class.php
+++ b/includes/Contact.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Contact')) {
+    
 class AC_Contact extends ActiveCampaign {
 
 	public $version;
@@ -118,4 +120,5 @@ class AC_Contact extends ActiveCampaign {
 
 }
 
+}
 ?>

--- a/includes/Design.class.php
+++ b/includes/Design.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Design')) {    
+
 class AC_Design extends ActiveCampaign {
 
 	public $version;
@@ -28,4 +30,5 @@ class AC_Design extends ActiveCampaign {
 
 }
 
+}
 ?>

--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Form')) {
+    
 class AC_Form extends ActiveCampaign {
 
 	public $version;
@@ -260,4 +262,5 @@ var \$j = jQuery.noConflict();
 
 }
 
+}
 ?>

--- a/includes/Group.class.php
+++ b/includes/Group.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Group')) {
+    
 class AC_Group extends ActiveCampaign {
 
 	public $version;
@@ -51,5 +53,5 @@ class AC_Group extends ActiveCampaign {
 	}
 
 }
-
+}
 ?>

--- a/includes/List.class.php
+++ b/includes/List.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_List_')) {
+    
 class AC_List_ extends ActiveCampaign {
 
 	public $version;
@@ -87,5 +89,5 @@ class AC_List_ extends ActiveCampaign {
 	}
 
 }
-
+}
 ?>

--- a/includes/Message.class.php
+++ b/includes/Message.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Message')) {
+    
 class AC_Message extends ActiveCampaign {
 
 	public $version;
@@ -99,5 +101,5 @@ class AC_Message extends ActiveCampaign {
 	}
 
 }
-
+}
 ?>

--- a/includes/Subscriber.class.php
+++ b/includes/Subscriber.class.php
@@ -1,6 +1,10 @@
 <?php
 
+if(!class_exists('AC_Subscriber')) {
+    
 class AC_Subscriber extends AC_Contact {
+}
+
 }
 
 ?>

--- a/includes/Tracking.class.php
+++ b/includes/Tracking.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Tracking')) {
+    
 class AC_Tracking extends ActiveCampaign {
 
 	public $version;
@@ -115,4 +117,5 @@ class AC_Tracking extends ActiveCampaign {
 
 }
 
+}
 ?>

--- a/includes/User.class.php
+++ b/includes/User.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_User')) {
+    
 class AC_User extends ActiveCampaign {
 
 	public $version;
@@ -67,5 +69,5 @@ class AC_User extends ActiveCampaign {
 	}
 
 }
-
+}
 ?>

--- a/includes/Webhook.class.php
+++ b/includes/Webhook.class.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('AC_Webhook')) {
+    
 class AC_Webhook extends ActiveCampaign {
 
 	public $version;
@@ -81,4 +83,5 @@ class AC_Webhook extends ActiveCampaign {
 
 }
 
+}
 ?>


### PR DESCRIPTION
This occurred when working on a WordPress plugin using this library and another plugin using the same library. I am referring to ActiveCampaign Subscription Forms plugin. To resolve this I added if statement the avoid redeclaration.
