### PR TITLE
Form API response CSS classes

### DIFF
--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -121,6 +121,9 @@ var \$j = jQuery.noConflict();
 			},
 			success: function(data) {
 				\$j('#form_result_message').html(data.message);
+				var result_class = (data.success) ? 'form_result_success' : 'form_result_error';
+				\$j('#form_result_message').removeClass();
+				\$j('#form_result_message').addClass(result_class);
 			}
 		});
 

--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -123,7 +123,6 @@ var \$j = jQuery.noConflict();
 				\$j('#form_result_message').html(data.message);
 				var result_class = (data.success) ? 'form_result_success' : 'form_result_error';
 				\$j('#form_result_message').removeClass('form_result_success form_result_error').addClass(result_class);
-				\$j('#form_result_message').addClass(result_class);
 			}
 		});
 

--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -122,7 +122,7 @@ var \$j = jQuery.noConflict();
 			success: function(data) {
 				\$j('#form_result_message').html(data.message);
 				var result_class = (data.success) ? 'form_result_success' : 'form_result_error';
-				\$j('#form_result_message').removeClass();
+				\$j('#form_result_message').removeClass('form_result_success form_result_error').addClass(result_class);
 				\$j('#form_result_message').addClass(result_class);
 			}
 		});


### PR DESCRIPTION
When you submit a subscription form through our PHP wrapper (Ajax), we include some JavaScript that updates the DOM with a result message (IE: "Contact added," "Contact updated," etc). I added a class to the message div in the DOM based on success or failure with the Ajax call. This way developers can style the inline response message based on success or failure.