### PR TITLE
Option to disable sending header http

### DIFF
--- a/includes/ActiveCampaign.class.php
+++ b/includes/ActiveCampaign.class.php
@@ -16,6 +16,7 @@ class ActiveCampaign extends AC_Connector {
 	public $track_key;
 	public $version = 1;
 	public $debug = false;
+	public $set_header = true;
 
 	function __construct($url, $api_key, $api_user = "", $api_pass = "") {
 		$this->url_base = $this->url = $url;
@@ -101,6 +102,7 @@ class ActiveCampaign extends AC_Connector {
 		}
 
 		$class->debug = $this->debug;
+		$class->set_header = $this->set_header;
 
 		$response = $class->$method($params, $post_data);
 		return $response;

--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -202,7 +202,10 @@ class AC_Connector {
 			echo "<textarea style='height: 300px; width: 600px;'>" . $debug_str1 . "</textarea>";
 		}
 
-		header("HTTP/1.1 " . $http_code);
+		if ($this->set_header) {
+			header("HTTP/1.1 " . $http_code);
+		}
+
 		$object->http_code = $http_code;
 
 		if (isset($object->result_code)) {


### PR DESCRIPTION
Add options to disable header options (defaults to enabled for BC). 
I have my own exception handler that will set the http code at other place in requests. This header line broke my exception handler. And it truly broke those who uses rpc (such as thrift) that must not have `HTTP 1.1` in the header.

It should also fix #28 (which also happened to me and fixed by commenting out line 205 in Connector class). Actually I don't have any idea why you have this header line.
