### PR TITLE
Form captcha Ajax fix [#107326958]

### DIFF
--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -91,6 +91,9 @@ class AC_Form extends ActiveCampaign {
 				// forms come out of AC now with a "submit" button (it used to be "button").
 				$html = preg_replace("/input type='submit'/", "input type='button'", $html);
 
+				// Replace the external image (captcha) script with the local one, so the session var is accessible.
+				$html = preg_replace("/\/\/.*\/ac_global\/scripts\/randomimage\.php/i", "randomimage.php", $html);
+
 				$action_val = urldecode($action_val);
 
 				// add jQuery stuff


### PR DESCRIPTION
When embedding a form using the Ajax option, we replace the remote `randomimage.php` script reference with a local one, so the session variable is accessible when the captcha is verified.

See also the [WordPress plugin update](https://github.com/ActiveCampaign/app-wordpress/pull/12), and the [API example script update](https://github.com/ActiveCampaign/example-subscription_form_embed/pull/1).