### PR TITLE
API wrapper form instant responders [#110331390]

### DIFF
--- a/includes/Form.class.php
+++ b/includes/Form.class.php
@@ -216,6 +216,7 @@ var \$j = jQuery.noConflict();
 		foreach ($lists as $listid) {
 			$contact["p[{$listid}]"] = $listid;
 			$contact["status[{$listid}]"] = $status;
+			$contact["instantresponders[{$listid}]"] = 1;
 		}
 
 		if (!$sync) {


### PR DESCRIPTION
Include instant auto-responders when adding a contact via subscription form API request (affects the WordPress plugin).