### PR TITLE
Update Packagist datestamp [#114038301]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Official PHP wrapper for the ActiveCampaign API.",
 	"keywords": ["activecampaign", "email-marketing", "newsletter", "marketing-automation", "subscribe", "forms", "emails", "automation"],
 	"homepage": "https://github.com/ActiveCampaign/activecampaign-api-php",
-	"time": "2014-08-26",
+	"time": "2016-02-26",
 	"type": "library",
 	"license": "MIT",
 	"support": {


### PR DESCRIPTION
[It seems like](https://getcomposer.org/doc/04-schema.md#time) this value should always reflect the release date of the version. Currently it shows the wrong date for the current version:

![screen shot 2016-02-26 at 8 54 53 am](https://cloud.githubusercontent.com/assets/634489/13355602/d61d7562-dc66-11e5-9edf-4f67c16abc0b.png)