### PR TITLE
Save curl response error [#119276287]

### DIFF
--- a/includes/ActiveCampaign.class.php
+++ b/includes/ActiveCampaign.class.php
@@ -16,6 +16,7 @@ class ActiveCampaign extends AC_Connector {
 	public $track_key;
 	public $version = 1;
 	public $debug = false;
+	public $curl_response_error = "";
 
 	function __construct($url, $api_key, $api_user = "", $api_pass = "") {
 		$this->url_base = $this->url = $url;

--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -32,9 +32,9 @@ class AC_Connector {
 		if (is_object($r) && (int)$r->result_code) {
 			// successful
 			$r = true;
-		}
-		else {
-			// failed
+		} else {
+			// failed - log it
+			$this->curl_response_error = $r;
 			$r = false;
 		}
 		return $r;


### PR DESCRIPTION
If `credentials_test()` fails, save the actual response from the `curl()` method. We can then push this up to Zapier's endpoint so they see the error and can display that in their interface.