### PR TITLE
Fixing segment/list issue

### DIFF
--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -199,6 +199,8 @@ class AC_Connector {
 			$string_responses = array("tracking_event_remove", "contact_list", "form_html", "tracking_site_status", "tracking_event_status", "tracking_whitelist", "tracking_log", "tracking_site_list", "tracking_event_list");
 			if (in_array($method, $string_responses)) {
 				return $response;
+			}elseif ($method == 'segment_list'){
+				return $object;
 			}
 			// something went wrong
 			return "An unexpected problem occurred with the API request. Some causes include: invalid JSON or XML returned. Here is the actual response from the server: ---- " . $response;


### PR DESCRIPTION
Following code produces "An unexpected problem occurred with the API request." (image attached below the code)
```
$ac = new ActiveCampaign("API_URL", "API_KEY");
$ac->version(2);

$params = array(
		"sort" => "id",
		"sort_direction" => "DESC",
		"page" => 1,
);
$params = http_build_query($params);
	    
$response = $ac->api("segment/list?$params");
	
echo "<p>Segments:</p>";
echo "<pre>";
print_r($response);
echo "</pre>";
```

![image](https://cloud.githubusercontent.com/assets/17882120/18928085/98f20408-858c-11e6-802a-8846d497b97c.png)

Alternatively you can provide `result_code` or `success` in segment_list API output