### PR TITLE
segment_list response fix DEVJIRA-2064

### DIFF
--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -196,7 +196,7 @@ class AC_Connector {
 		}
 		if ( !is_object($object) || (!isset($object->result_code) && !isset($object->succeeded) && !isset($object->success)) ) {
 			// add methods that only return a string
-			$string_responses = array("tracking_event_remove", "contact_list", "form_html", "tracking_site_status", "tracking_event_status", "tracking_whitelist", "tracking_log", "tracking_site_list", "tracking_event_list");
+			$string_responses = array("segment_list", "tracking_event_remove", "contact_list", "form_html", "tracking_site_status", "tracking_event_status", "tracking_whitelist", "tracking_log", "tracking_site_list", "tracking_event_list");
 			if (in_array($method, $string_responses)) {
 				return $response;
 			}


### PR DESCRIPTION
Fix for `segment_list` response outputting "An unexpected problem occurred ..." error message.

This is a v2 API call that doesn't have the `result_code` or `result_message` keys in the response, so we assume something invalid came back in the API response.

We really just needed to whitelist this API method (like we do for other methods that don't include that extra information).