### PR TITLE
Fixed tags_list response

### DIFF
--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -203,6 +203,12 @@ class AC_Connector {
 				return $response;
 			}
 
+			// add methods that don't return a success key in the response
+			$array_responses = array("tags_list");
+			if (in_array($method, $array_responses)) {
+				return $object;
+			}
+
 			$requestException = new RequestException;
 			$requestException->setFailedMessage($response);
 			throw $requestException;


### PR DESCRIPTION
The `tags_list` response doesn't contain the `result_code`, `succeeded` or `success` keys that are required for the response not to error out.

This PR handles responses that don't include those, in the same way that you handle ones that only respond with a string.
