### PR TITLE
tags_list response fix DEVJIRA-2603

### DIFF
--- a/includes/Connector.class.php
+++ b/includes/Connector.class.php
@@ -198,7 +198,7 @@ class AC_Connector {
 		}
 		if ( !is_object($object) || (!isset($object->result_code) && !isset($object->succeeded) && !isset($object->success)) ) {
 			// add methods that only return a string
-			$string_responses = array("segment_list", "tracking_event_remove", "contact_list", "form_html", "tracking_site_status", "tracking_event_status", "tracking_whitelist", "tracking_log", "tracking_site_list", "tracking_event_list");
+			$string_responses = array("tags_list", "segment_list", "tracking_event_remove", "contact_list", "form_html", "tracking_site_status", "tracking_event_status", "tracking_whitelist", "tracking_log", "tracking_site_list", "tracking_event_list");
 			if (in_array($method, $string_responses)) {
 				return $response;
 			}


### PR DESCRIPTION
Fix for `tags_list` method returning a failure because it's missing `result_code` and `succeeded` response keys.

This will allow the raw response to be returned, and then it just needs to be decoded outside of the wrapper.

v2.0.1