### PR TITLE
Change Credentials Test Method to Throw Exception

### DIFF
--- a/includes/Connector.php
+++ b/includes/Connector.php
@@ -77,21 +77,16 @@ class Connector
     }
 
     /**
-     * Test the api credentials
+     * Test the api credentials. Will throw an exception if credentials are not valid
      *
-     * @return bool|mixed
-     * @throws \RequestException
+     * @return true
+     * @throws RequestException
      */
     public function credentials_test()
     {
         $test_url = "{$this->url}&api_action=user_me&api_output={$this->output}";
-        $r = true;
-        try {
-            $this->curl($test_url);
-        } catch (\Exception $e) {
-            $r = false;
-        }
-        return $r;
+        $this->curl($test_url);
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR updates the method `Connection#credentials_test` to throw an exception if there are invalid credentials rather than returning a boolean. This will allow for developers to better see the cause of the credential failure. 

@ActiveCampaign/integration 