### PR TITLE
Add Greater Context to AC Exceptions

### DIFF
--- a/includes/ActiveCampaign.php
+++ b/includes/ActiveCampaign.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace ActiveCampaign\Api\V1;
+
 use ActiveCampaign\Api\V1\Exceptions\InvalidArgumentException;
 
 /**

--- a/includes/Connector.php
+++ b/includes/Connector.php
@@ -336,15 +336,15 @@ class Connector
                     $this->throwRequestException(curl_error($request), $request, $data);
                     break;
             }
-        }
-
-        $http_code = (string)curl_getinfo($request, CURLINFO_HTTP_CODE);
-        if (preg_match("/^4.*/", $http_code)) {
-            // 4** status code
-            $exception = new ClientException($response, $http_code);
-        } elseif (preg_match("/^5.*/", $http_code)) {
-            // 5** status code
-            $exception = new ServerException($response, $http_code);
+        } else {
+            $http_code = (string)curl_getinfo($request, CURLINFO_HTTP_CODE);
+            if (preg_match("/^4.*/", $http_code)) {
+                // 4** status code
+                $exception = new ClientException($response, $http_code);
+            } elseif (preg_match("/^5.*/", $http_code)) {
+                // 5** status code
+                $exception = new ServerException($response, $http_code);
+            }
         }
 
         if (!$exception) {
@@ -352,8 +352,8 @@ class Connector
         }
 
         $exception->setContext(array(
-            "request_url"  => curl_getinfo($request, CURLINFO_EFFECTIVE_URL),
-            "request_body" => json_encode($data)
+            "api_request_url"  => curl_getinfo($request, CURLINFO_EFFECTIVE_URL),
+            "api_request_body" => json_encode($data)
         ));
 
         throw $exception;

--- a/includes/Connector.php
+++ b/includes/Connector.php
@@ -245,9 +245,9 @@ class Connector
 
         $response = curl_exec($request);
 
-        $dataForLog = count($params_data) > 0 ? $data : null;
+        $data = isset($data) ? $data : null;
 
-        $this->checkForRequestErrors($request, $response, $dataForLog);
+        $this->checkForRequestErrors($request, $response, $data);
 
         $http_code = (string)curl_getinfo($request, CURLINFO_HTTP_CODE);
 
@@ -262,7 +262,7 @@ class Connector
                 return $response;
             }
 
-            $this->throwRequestException($response, $request, $dataForLog);
+            $this->throwRequestException($response, $request, $data);
         }
 
         $object->http_code = $http_code;

--- a/includes/Connector.php
+++ b/includes/Connector.php
@@ -245,7 +245,9 @@ class Connector
 
         $response = curl_exec($request);
 
-        $this->checkForRequestErrors($request, $response);
+        $dataForLog = count($params_data) > 0 ? $data : null;
+
+        $this->checkForRequestErrors($request, $response, $dataForLog);
 
         $http_code = (string)curl_getinfo($request, CURLINFO_HTTP_CODE);
 
@@ -260,7 +262,7 @@ class Connector
                 return $response;
             }
 
-            $this->throwRequestException($response);
+            $this->throwRequestException($response, $request, $dataForLog);
         }
 
         $object->http_code = $http_code;
@@ -286,13 +288,23 @@ class Connector
     /**
      * Throw the request exception
      *
-     * @param $message
+     * @param string $message
+     * @param resource $request
+     * @param string $data
      *
-     * @throws \RequestException
+     * @throws RequestException
      */
-    protected function throwRequestException($message)
+    protected function throwRequestException($message, $request = null, $data = null)
     {
         $requestException = new RequestException;
+
+        if ($request) {
+            $requestException->setContext(array(
+                "request_url"  => curl_getinfo($request, CURLINFO_EFFECTIVE_URL),
+                "request_body" => json_encode($data)
+            ));
+        }
+
         $requestException->setFailedMessage($message);
 
         throw $requestException;
@@ -301,24 +313,27 @@ class Connector
     /**
      * Checks the cURL request for errors and throws exceptions appropriately
      *
-     * @param $request
-     * @param $response string The response from the request
+     * @param resource $request
+     * @param string $response The response from the request
+     * @param string $data     The post data if it exists
      * @throws RequestException
      * @throws ClientException
      * @throws ServerException
      * @throws TimeoutException
      */
-    protected function checkForRequestErrors($request, $response)
+    protected function checkForRequestErrors($request, $response, $data = null)
     {
+        $exception = null;
+
         // if curl has an error number
         if (curl_errno($request)) {
             switch (curl_errno($request)) {
                 // curl timeout error
                 case CURLE_OPERATION_TIMEDOUT:
-                    throw new TimeoutException(curl_error($request));
+                    $exception = new TimeoutException(curl_error($request));
                     break;
                 default:
-                    $this->throwRequestException(curl_error($request));
+                    $this->throwRequestException(curl_error($request), $request, $data);
                     break;
             }
         }
@@ -326,10 +341,21 @@ class Connector
         $http_code = (string)curl_getinfo($request, CURLINFO_HTTP_CODE);
         if (preg_match("/^4.*/", $http_code)) {
             // 4** status code
-            throw new ClientException($response, $http_code);
+            $exception = new ClientException($response, $http_code);
         } elseif (preg_match("/^5.*/", $http_code)) {
             // 5** status code
-            throw new ServerException($response, $http_code);
+            $exception = new ServerException($response, $http_code);
         }
+
+        if (!$exception) {
+            return;
+        }
+
+        $exception->setContext(array(
+            "request_url"  => curl_getinfo($request, CURLINFO_EFFECTIVE_URL),
+            "request_body" => json_encode($data)
+        ));
+
+        throw $exception;
     }
 }

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -52,14 +52,12 @@ class RequestException extends \Exception
     /**
      * @param array $context
      *
-     * @return array|null
+     * @return $this
      */
-    public function setContext($context)
+    public function setContext(array $context)
     {
-        if (is_array($context)) {
-            $this->context = $context;
-        }
+        $this->context = $context;
 
-        return $this->context;
+        return $this;
     }
 }

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -5,6 +5,13 @@ namespace ActiveCampaign\Api\V1\Exceptions;
 class RequestException extends \Exception
 {
     /**
+     * Optional context for the exception
+     *
+     * @var array
+     */
+    public $context;
+
+    /**
      * The message returned by the failed request
      *
      * @var string
@@ -12,7 +19,7 @@ class RequestException extends \Exception
     private $failedRequestMessage;
 
     /**
-     * @param string message    Response error message from the server.
+     * @param string $message Response error message from the server.
      *
      * Set the failure message for this exception.
      */
@@ -30,5 +37,27 @@ class RequestException extends \Exception
     public function getFailedMessage()
     {
         return $this->failedRequestMessage;
+    }
+
+    /**
+     * Gets the context
+     *
+     * @return array
+     */
+    public function getContext() {
+        return $this->context;
+    }
+
+    /**
+     * @param array $context
+     *
+     * @return array|null
+     */
+    public function setContext($context) {
+        if (is_array($context)) {
+            $this->context = $context;
+        }
+
+        return $this->context;
     }
 }

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -44,7 +44,8 @@ class RequestException extends \Exception
      *
      * @return array
      */
-    public function getContext() {
+    public function getContext()
+    {
         return $this->context;
     }
 
@@ -53,7 +54,8 @@ class RequestException extends \Exception
      *
      * @return array|null
      */
-    public function setContext($context) {
+    public function setContext($context)
+    {
         if (is_array($context)) {
             $this->context = $context;
         }

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -9,7 +9,7 @@ class RequestException extends \Exception
      *
      * @var array
      */
-    public $context;
+    private $context;
 
     /**
      * The message returned by the failed request


### PR DESCRIPTION
This PR adds a private property `$context` to the `RequestException` class (and all inheritors). The property can be accessed through get/set methods. The point of this property is to add context to exceptions being thrown. The property, when added, is an associative array with two keys:

```php
array(
    "request_url" => //,
    "request_body" => // is json_encoded
)
```

The intent is to add greater verbosity to all RequestExceptions to aid in faster debugging. 

Additionally, this PR refactors the `Connector` class to add in the context to the exception when there's an issue with cURL requests.

@ActiveCampaign/integration 