### PR TITLE
Update RequestException to remove legacy code

### DIFF
--- a/includes/Connector.php
+++ b/includes/Connector.php
@@ -296,7 +296,7 @@ class Connector
      */
     protected function throwRequestException($message, $request = null, $data = null)
     {
-        $requestException = new RequestException;
+        $requestException = new RequestException($message);
 
         if ($request) {
             $requestException->setContext(array(
@@ -304,8 +304,6 @@ class Connector
                 "request_body" => json_encode($data)
             ));
         }
-
-        $requestException->setFailedMessage($message);
 
         throw $requestException;
     }

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -11,7 +11,6 @@ class RequestException extends \Exception
      * Optional context for the exception
      *
      * @var array
-     * @default []
      */
     private $context = array();
 

--- a/includes/Exceptions/RequestException.php
+++ b/includes/Exceptions/RequestException.php
@@ -2,42 +2,18 @@
 
 namespace ActiveCampaign\Api\V1\Exceptions;
 
+/**
+ * Class RequestException
+ */
 class RequestException extends \Exception
 {
     /**
      * Optional context for the exception
      *
      * @var array
+     * @default []
      */
-    private $context;
-
-    /**
-     * The message returned by the failed request
-     *
-     * @var string
-     */
-    private $failedRequestMessage;
-
-    /**
-     * @param string $message Response error message from the server.
-     *
-     * Set the failure message for this exception.
-     */
-    public function setFailedMessage($message)
-    {
-        $this->failedRequestMessage = $message;
-        $this->message = sprintf('An unexpected problem occurred with the API request. Some causes include: invalid JSON or XML returned. Here is the actual response from the server: ---- %s', $message);
-    }
-
-    /**
-     * @return string    Response error message from the server.
-     *
-     * Get the failure message for this exception.
-     */
-    public function getFailedMessage()
-    {
-        return $this->failedRequestMessage;
-    }
+    private $context = array();
 
     /**
      * Gets the context


### PR DESCRIPTION
This PR removes the `$failedRequestMessage` property and associated methods. Additionally, it adds a default value to `$context`.