### PR TITLE
fix set tracking params

### DIFF
--- a/includes/ActiveCampaign.class.php
+++ b/includes/ActiveCampaign.class.php
@@ -70,6 +70,17 @@ class ActiveCampaign extends AC_Connector {
 		parent::__construct($url, $api_key, $api_user, $api_pass);
 	}
 
+    /**
+	 * Set Tracking credentials
+	 *
+	 * @param string $track_actid
+	 * @param string $track_key
+	 */
+    function setTrackCredentials($track_actid, $track_key) {
+        $this->track_actid = $track_actid;
+        $this->track_key = $track_key;
+    }
+
 	/**
 	 * Set the version on the url
 	 *


### PR DESCRIPTION
There's a bug dropped at method `AC_Tracking::log`. Properties `track_actid` and `track_key` are never set.

Added a setter.
Use example:

```
$this->client = new ActiveCampaign(API_ENDPOINT, API_KEY);
$this->client->setTrackCredentials(TRACK_ACTID, TRACK_KEY);
```
